### PR TITLE
Update config to match the reworked as2_state_estimator architecture

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,17 +14,34 @@
   # State Estimator
   state_estimator:
     ros__parameters:
-      # # Indoor Raw Odometry
-      # plugin_name: "raw_odometry"
-      # # Indoor Motion Capture
-      # plugin_name: "mocap_pose"
-      # mocap_topic: "/mocap/rigid_bodies"
-      # twist_smooth_filter_cte: 0.1
-      # orientation_smooth_filter_cte: 0.1
       # Outdoor (GPS) Raw Odometry
       plugin_name: "raw_odometry"
-      use_gps: true
-      set_origin_on_start: true
+      raw_odometry:
+        use_gps: true  # earth->map comes from the first GPS fix.
+        
+      # # Outdoor (GPS), fused with the IMU (simple_ekf)
+      # # Might need sensor_measurements/imu and covariance tuning.
+      # plugin_name: "simple_ekf"
+      # simple_ekf:
+      #   earth_map_transform:
+      #     static_tf: true  
+      #     set_earth_map: true  # Manually set earth to map transform if true.
+      #     position:
+      #       x: 0.0
+      #       y: 0.0
+      #       z: 0.0
+      #     orientation:
+      #       roll: 0.0
+      #       pitch: 0.0
+      #       yaw: 0.0
+      #   update_topics: ["odom"]
+      #   odom:
+      #     topic: "sensor_measurements/odom"
+      #     type: "nav_msgs/msg/Odometry"
+      #     set_earth_map: false  # Dead-reckoned: must not define the world origin.
+      #     use_message_covariance: true
+      #     position_multiplier: [1.0, 1.0, 1.0]
+      #     orientation_multiplier: [1.0, 1.0, 1.0]
 
   # Behaviors Motion
   TakeoffBehavior:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,10 +17,9 @@
       # Outdoor (GPS) Raw Odometry
       plugin_name: "raw_odometry"
       raw_odometry:
-        use_gps: true  # Anchor earth at a GPS datum. By default the first fix received becomes the datum.
+        use_gps: true  # Anchor tf tree at a GPS first measurement.
 
-        # # Datum pinned to a surveyed point instead of the first fix, so earth lands in the
-        # # same place on every flight and GPS waypoints stay comparable across sessions.
+        # # Tf tree is anchored at manually set GPS coordinates.
         # gps_origin:
         #   set_origin: "manual"
         #   coordinates:
@@ -28,48 +27,9 @@
         #     longitude: -3.7038
         #     altitude: 667.0
 
-        # # Datum supplied at runtime by the set_origin service (drone.gps.set_origin in
-        # # as2_python_api). earth->map is not published until it is called, so the TF tree
-        # # stays incomplete until then.
+        # # Tf tree is anchored at GPS coordinates served by a service. The service must be called by the user.
         # gps_origin:
         #   set_origin: "service"
-
-        # # Pin map explicitly instead of placing it at the first fix. Composes with use_gps:
-        # # GPS still supplies the datum served by get_origin.
-        # earth_map_transform:
-        #   set_earth_map: true
-        #   position:
-        #     x: 0.0
-        #     y: 0.0
-        #     z: 0.0
-        #   orientation:
-        #     roll: 0.0
-        #     pitch: 0.0
-        #     yaw: 0.0
-
-      # # IMU fused with odometry (simple_ekf):
-      # # Might need sensor_measurements/imu and covariance tuning.
-      # plugin_name: "simple_ekf"
-      # simple_ekf:
-      #   earth_map_transform:
-      #     static_tf: true  
-      #     set_earth_map: true  # Manually set earth to map transform if true.
-      #     position:
-      #       x: 0.0
-      #       y: 0.0
-      #       z: 0.0
-      #     orientation:
-      #       roll: 0.0
-      #       pitch: 0.0
-      #       yaw: 0.0
-      #   update_topics: ["odom"]
-      #   odom:
-      #     topic: "sensor_measurements/odom"
-      #     type: "nav_msgs/msg/Odometry"
-      #     set_earth_map: false  # Dead-reckoned: must not define the world origin.
-      #     use_message_covariance: true
-      #     position_multiplier: [1.0, 1.0, 1.0]
-      #     orientation_multiplier: [1.0, 1.0, 1.0]
 
   # Behaviors Motion
   TakeoffBehavior:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,9 +17,37 @@
       # Outdoor (GPS) Raw Odometry
       plugin_name: "raw_odometry"
       raw_odometry:
-        use_gps: true  # earth->map comes from the first GPS fix.
-        
-      # # Outdoor (GPS), fused with the IMU (simple_ekf)
+        use_gps: true  # Anchor earth at a GPS datum. By default the first fix received becomes the datum.
+
+        # # Datum pinned to a surveyed point instead of the first fix, so earth lands in the
+        # # same place on every flight and GPS waypoints stay comparable across sessions.
+        # gps_origin:
+        #   set_origin: "manual"
+        #   coordinates:
+        #     latitude: 40.4168
+        #     longitude: -3.7038
+        #     altitude: 667.0
+
+        # # Datum supplied at runtime by the set_origin service (drone.gps.set_origin in
+        # # as2_python_api). earth->map is not published until it is called, so the TF tree
+        # # stays incomplete until then.
+        # gps_origin:
+        #   set_origin: "service"
+
+        # # Pin map explicitly instead of placing it at the first fix. Composes with use_gps:
+        # # GPS still supplies the datum served by get_origin.
+        # earth_map_transform:
+        #   set_earth_map: true
+        #   position:
+        #     x: 0.0
+        #     y: 0.0
+        #     z: 0.0
+        #   orientation:
+        #     roll: 0.0
+        #     pitch: 0.0
+        #     yaw: 0.0
+
+      # # IMU fused with odometry (simple_ekf):
       # # Might need sensor_measurements/imu and covariance tuning.
       # plugin_name: "simple_ekf"
       # simple_ekf:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

# Update config to match the reworked `as2_state_estimator`

> **Depends on** the `aerostack2` PR *"Rework `as2_state_estimator`: decouple plugins from
> state publishing + new `simple_ekf` plugin"*. Merge that first — these parameters do not
> exist on the current `main` of `aerostack2`, and the old ones are silently ignored by the
> new estimator.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Issue(s) this addresses | - |
| ROS2 version tested on | Humble |
| Aerial platform tested on | DJI (OSDK) — configuration verified to launch |

---

## Description of contribution in a few bullet points

* **`use_gps` nested under `raw_odometry:`.** Per-plugin parameters now live in a block
  named after the plugin. This matters more than it looks: a stale top-level key is
  *silently ignored* rather than rejected, so leaving it would have produced a node that
  starts normally with GPS quietly disabled.
* **Dropped `set_origin_on_start`.** The parameter no longer exists, when `use_gps` is set,
  the first GPS fix always establishes the origin, which is exactly what the flag used to
  gate.
* **Removed the stale commented indoor alternatives** (raw odometry / `mocap_pose`), which
  referenced parameters and a plugin that no longer exist.
* **Added a commented `simple_ekf` alternative** fusing the platform odometry with the IMU,
  including an explicit `earth_map_transform` block for setting the map origin manually.

**Behaviour: equivalent.** GPS still defines `earth→map` from the first fix, as before.

---

## Future work that may be required in bullet points

* Fly the GPS path to confirm the origin is established identically to the old
  `set_origin_on_start` behaviour. The code paths are equivalent, but this has not been
  verified outdoors.
